### PR TITLE
fix perl_curl_multi_delete  for GlobalDestruction

### DIFF
--- a/Curl_Multi.xsh
+++ b/Curl_Multi.xsh
@@ -48,6 +48,11 @@ perl_curl_multi_delete( pTHX_ perl_curl_multi_t *multi )
 /*{{{*/ {
 	perl_curl_multi_callback_code_t i;
 
+	if ( multi->handle ) {
+		curl_multi_setopt( multi->handle, CURLMOPT_SOCKETFUNCTION, NULL );
+		curl_multi_setopt( multi->handle, CURLMOPT_TIMERFUNCTION, NULL );
+	}
+
 	/* remove and mortalize all easy handles */
 	if ( multi->easies ) {
 		simplell_t *next, *now = multi->easies;


### PR DESCRIPTION
Hello.
This is the fix to prevent segmentation fault, when GlobalDestruction worked

Program terminated with signal SIGSEGV, Segmentation fault.
(gdb) bt
#0  0x081042f1 in Perl_sv_bless ()
#1  0xf70caa75 in cb_multi_socket (easy_handle=0x999a768, s=20, what=4, userptr=0x996e038, socketp=0x0) at curl-Multi-c.inc:93
#2  0xf7065f31 in Curl_multi_closed (conn=0x99d62c8, s=20) at multi.c:2433
#3  0xf7062a23 in Curl_closesocket (conn=0x99d62c8, sock=20) at connect.c:1294
#4  0xf704f9f5 in conn_free (conn=0x9468d60) at url.c:2763
#5  0xf70527f0 in Curl_disconnect (conn=0x99d62c8, dead_connection=true) at url.c:2864
#6  0xf706488c in multi_done (connp=0x9468d60, connp@entry=0x999a770, status=CURLE_OK, premature=true) at multi.c:616
#7  0xf70668f1 in curl_multi_remove_handle (multi=0x996a630, data=0x999a768) at multi.c:717
#8  0xf70cbd95 in perl_curl_multi_delete (multi=<optimized out>, my_perl=<optimized out>) at curl-Multi-c.inc:57
#9  perl_curl_multi_magic_free (my_perl=0x8a19008, sv=0x95a5b34, mg=0x9468d60) at curl-Multi-c.inc:134