### PR TITLE
The data may come in more than one read

### DIFF
--- a/t/old-22sendrecv.t
+++ b/t/old-22sendrecv.t
@@ -51,9 +51,11 @@ $cnt = select $rout = $vec, undef, $eout = $vec, 2;
 ok( $cnt, "ready to read" );
 
 my $buffer;
-
+my $received = 0;
 eval {
-	$c->recv( $buffer, 1024 * 16 );
+	while ($received < $sent) {
+		$received += $c->recv( $buffer, 1024 * 16 );
+	}
 };
 ok( !$@, "received data" );
 


### PR DESCRIPTION
Make sure we actually receive all the data.

Without this change, in a very loaded machine, you could end up
with the "no more data to read" failure. This makes as many recv
calls as necessary before making the one that should fail.