### PR TITLE
Support CURLOPT_CONNECT_TO

### DIFF
--- a/Curl_Easy.xsh
+++ b/Curl_Easy.xsh
@@ -39,6 +39,9 @@ static const CURLoption perl_curl_easy_option_slist[] = {
 #ifdef CURLOPT_RESOLVE
 	CURLOPT_RESOLVE,
 #endif
+#ifdef CURLOPT_CONNECT_TO
+	CURLOPT_CONNECT_TO,
+#endif
 	CURLOPT_TELNETOPTIONS
 };
 #define perl_curl_easy_option_slist_num \


### PR DESCRIPTION
`CURLOPT_CONNECT_TO` is missing from Curl_Easy.xsh

https://curl.haxx.se/libcurl/c/CURLOPT_CONNECT_TO.html