### PR TITLE
Fix failure to remove freed easy objects from multi->easies.

### DIFF
--- a/Curl_Easy.xsh
+++ b/Curl_Easy.xsh
@@ -153,6 +153,16 @@ perl_curl_easy_remove_from_multi( pTHX_  perl_curl_easy_t* easy )
 
 	if (easy->multi) {
 		ret = curl_multi_remove_handle( easy->multi->handle, easy->handle );
+
+		{
+			SV *easysv;
+			easysv = perl_curl_simplell_del( aTHX_ &easy->multi->easies,
+				PTR2nat( easy ) );
+			if ( !easysv )
+				croak( "internal Net::Curl error" );
+			sv_2mortal( easysv );
+		}
+
 		easy->multi = NULL;
 	}
 

--- a/Curl_Multi.xsh
+++ b/Curl_Multi.xsh
@@ -237,14 +237,6 @@ remove_handle( multi, easy )
 				easy->multi ? "this" : "any" );
 
 		ret = perl_curl_easy_remove_from_multi( aTHX_ easy );
-		{
-			SV *easysv;
-			easysv = perl_curl_simplell_del( aTHX_ &multi->easies,
-				PTR2nat( easy ) );
-			if ( !easysv )
-				croak( "internal Net::Curl error" );
-			sv_2mortal( easysv );
-		}
 
 		/* rethrow errors */
 		if ( SvTRUE( ERRSV ) )


### PR DESCRIPTION
Issue #37: This caused SIGBUS on FreeBSD 13 and OpenBSD 6.6 in certain
Perl garbage-collection scenarios.

Testing confirmed this fix in FreeBSD 13 and noted no regressions in
FreeBSD, macOS, Linux, and NetBSD.