### PR TITLE
Skip t/cleanup.t in Perl 5.8.9.

### DIFF
--- a/t/assets/end_42_on_die.pl
+++ b/t/assets/end_42_on_die.pl
@@ -1,0 +1,10 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+die "ohno";
+
+END {
+    $? = 42;
+}

--- a/t/cleanup.t
+++ b/t/cleanup.t
@@ -5,7 +5,16 @@ use warnings;
 
 use FindBin;
 
-use Test::More tests => 1;
+use Test::More;
+
+system $^X, "$FindBin::Bin/assets/add_then_throw.pl";
+
+if ($? != (42 << 8)) {
+    require Config;
+    plan skip_all => "This perl ($Config::Config{'version'}) doesn’t appear to set exit value from \$? in END.\n";
+}
+
+plan tests => 1;
 
 my @inc_args = map { ('-I', $_) } @INC;
 


### PR DESCRIPTION
It appears that old perls on some OSes (e.g., macOS) do not set the
process exit value when $? is set during an END block. We depend on
this behavior in t/cleanup.t, so we have to skip that test in such
perls.

For reference: http://www.cpantesters.org/cpan/report/afb00dd6-527d-11ea-bd64-20201f24ea8f