### PR TITLE
fix compiling with curl-7.70.0

### DIFF
--- a/inc/symbols-in-versions
+++ b/inc/symbols-in-versions
@@ -936,7 +936,7 @@ CURL_VERSION_BROTLI             7.57.0
 CURL_VERSION_CONV               7.15.4
 CURL_VERSION_CURLDEBUG          7.19.6
 CURL_VERSION_DEBUG              7.10.6
-CURL_VERSION_ESNI               7.67.0
+CURL_VERSION_ESNI               7.67.0        7.69.9        7.70.0
 CURL_VERSION_GSSAPI             7.38.0
 CURL_VERSION_GSSNEGOTIATE       7.10.6        7.38.0
 CURL_VERSION_HTTP2              7.33.0


### PR DESCRIPTION
This fixes:
https://pkgsubmit.mageia.org/autobuild/cauldron/x86_64/core/2020-05-20/perl-Net-Curl-0.440.0-1.mga8.src.rpm/build.0.20200521102712.log

    Failed test 'CURL_VERSION_ESNI constant can be retrieved'
    at t/01-constants.t line 51.
           got: 'Undefined subroutine &main::CURL_VERSION_ESNI called at (eval 3594) line 1.
  '
      expected: ''

    Failed test 'CURL_VERSION_ESNI is defined'
    at t/01-constants.t line 52.

    Failed test 'CURL_VERSION_ESNI value is an integer'
    at t/01-constants.t line 53.
                    undef
      doesn't match '(?^:^-?\d+$)'
  Looks like you failed 3 tests of 2746.
t/01-constants.t ...........................

    Failed test 'CURL_VERSION_ESNI is defined alright - Invalid argument'
    at t/compat-00constants.t line 63.
  Looks like you failed 1 test of 908.
t/compat-00constants.t .....................
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/908 subtests