### PR TITLE
Add CURLINFO_CERTINFO support.

### DIFF
--- a/lib/Net/Curl/Easy.pm
+++ b/lib/Net/Curl/Easy.pm
@@ -157,6 +157,9 @@ Retrieve a value. OPTION is one of C<CURLINFO_*> constants.
 Calls L<curl_easy_getinfo(3)|https://curl.haxx.se/libcurl/c/curl_easy_getinfo.html>.
 Throws L</Net::Curl::Easy::Code> on error.
 
+In the case of C<CURLINFO_CERTINFO>, the return is an array reference of
+hash references; each hash represents one certificate.
+
 =item pause( )
 
 Pause the transfer.


### PR DESCRIPTION
This is useful for applications that need to display information about TLS verification failures.