### PR TITLE
SIGSEGV in cb_multi_socket

### DIFF
--- a/Curl_Multi.xsh
+++ b/Curl_Multi.xsh
@@ -66,9 +66,18 @@ cb_multi_socket( CURL *easy_handle, curl_socket_t s, int what, void *userptr,
 	perl_curl_multi_t *multi;
 	perl_curl_easy_t *easy;
 
+	if (userptr == NULL) 
+		return 0;
+
 	multi = (perl_curl_multi_t *) userptr;
 
+	if (multi->cb[ CB_MULTI_SOCKET ].func == NULL) 
+		return 0;
+
 	(void) curl_easy_getinfo( easy_handle, CURLINFO_PRIVATE, (void *) &easy );
+
+	if (easy == NULL) 
+		return 0;
 
 	/* $multi, $easy, $socket, $what, $socketdata, $userdata */
 	SV *args[] = {


### PR DESCRIPTION
Hi!

[Issue #77](https://github.com/sparky/perl-Net-Curl/issues/77)

The problem occurs when building with fresh versions of curl when using the multi interface. In my case, it's 8.14.1.

The problem is caused by the fact that the callback _cb_multi_socket_ is called after the  function _perl_curl_multi_magic_free_ has released memory, which leads to a SEGFAULT.

[My comment](https://github.com/sparky/perl-Net-Curl/issues/77#issuecomment-3023800732)

