### PR TITLE
Fix SEGFAULT in cb_multi_socket. $easy can be NULL, if $what == CURL_…

### DIFF
--- a/Curl_Multi.xsh
+++ b/Curl_Multi.xsh
@@ -69,11 +69,13 @@ cb_multi_socket( CURL *easy_handle, curl_socket_t s, int what, void *userptr,
 	multi = (perl_curl_multi_t *) userptr;
 
 	(void) curl_easy_getinfo( easy_handle, CURLINFO_PRIVATE, (void *) &easy );
+    
 
 	/* $multi, $easy, $socket, $what, $socketdata, $userdata */
+	/* $easy can be NULL if $what == CURL_POLL_REMOVE */
 	SV *args[] = {
 		/* 0 */ SELF2PERL( multi ),
-		/* 1 */ SELF2PERL( easy ),
+		/* 1 */ easy ? SELF2PERL( easy ) : NULL,
 		/* 2 */ newSVuv( s ),
 		/* 3 */ newSViv( what ),
 		/* 4 */ &PL_sv_undef

--- a/Curl_Multi.xsh
+++ b/Curl_Multi.xsh
@@ -75,7 +75,7 @@ cb_multi_socket( CURL *easy_handle, curl_socket_t s, int what, void *userptr,
 	/* $easy can be NULL if $what == CURL_POLL_REMOVE */
 	SV *args[] = {
 		/* 0 */ SELF2PERL( multi ),
-		/* 1 */ easy ? SELF2PERL( easy ) : NULL,
+		/* 1 */ easy ? SELF2PERL( easy ) : &PL_sv_undef,
 		/* 2 */ newSVuv( s ),
 		/* 3 */ newSViv( what ),
 		/* 4 */ &PL_sv_undef


### PR DESCRIPTION
Hi,

[Issue 77](https://github.com/sparky/perl-Net-Curl/issues/77)

It seems that the problem arises here in Curl_Multi.xsh:
```C
static int
cb_multi_socket( CURL *easy_handle, curl_socket_t s, int what, void *userptr,
                void *socketp )
...
        (void) curl_easy_getinfo( easy_handle, CURLINFO_PRIVATE, (void *) &easy );
        /* easy is NULL here, if what == CURL_POLL_REMOVE, because easy_handle 
           is an internal libcurl `admin` pointer. */

        /* $multi, $easy, $socket, $what, $socketdata, $userdata */
        SV *args[] = {
                /* 0 */ SELF2PERL( multi ),
                /* 1 */ SELF2PERL( easy ), /* segfault here */
```
If the parameter what == CURL_POLL_REMOVE, then easy_handle can be an internal handle, and in the new curl, it is a special _multi->admin_ handle.
[Callback arguments](https://curl.se/libcurl/c/CURLMOPT_SOCKETFUNCTION.html)

> Since this callback manages a whole multi handle, an application should not make assumptions about which particular handle that is passed here. It might even be an internal easy handle that the application did not add itself.

It might be better to call perl-callback with NULL in the easy parameter:
```C
SV *args[] = {
                /* 0 */ SELF2PERL( multi ),
                /* 1 */ easy ? SELF2PERL( easy ) : NULL,
```
